### PR TITLE
Implement fallback paste service and fix command check in ytm function

### DIFF
--- a/plugins/yt.py
+++ b/plugins/yt.py
@@ -15,7 +15,7 @@ yt_music = YTMusic()
 
 @Client.on_message(~filters.scheduled & command(["ytm"]) & filters.me & ~filters.forwarded)
 async def ytm(_, message: Message):
-    if len(message.command) == 1 and message.command[0] != "rpy":
+    if len(message.command) == 1 and message.command[0] != "ytm":
         return await message.edit_text("<b>Query to search isn't provided</b>")
 
     await message.edit_text("<b><emoji id=5821116867309210830>🔃</emoji> Searching...</b>")

--- a/utils/scripts.py
+++ b/utils/scripts.py
@@ -107,6 +107,15 @@ def with_premium(func):
     return wrapped
 
 
+async def dpaste(code: str):
+    async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        data = {"content": code, "lexer": "python", "expires": "never"}
+        async with session.post("https://dpaste.org/api/", data=data) as resp:
+            if resp.status != 200:
+                return "Pasting failed!"
+            else:
+                return (await resp.text()).replace('"', "")
+
 async def paste_neko(code: str):
     try:
         async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
@@ -117,7 +126,7 @@ async def paste_neko(code: str):
                 paste.raise_for_status()
                 result = await paste.json()
     except Exception:
-        return "Pasting failed"
+        return await dpaste(code=code)
     else:
         return f"nekobin.com/{result['result']['key']}.py"
 


### PR DESCRIPTION
Implement fallback paste service and fix command check in ytm function

- Added a new paste function `dpaste` to handle cases where Nekobin service fails.
- Updated `paste_neko` function to use `dpaste` as a fallback option in case of an exception.
- Ensured the fallback paste service maintains functionality and reliability.
- Fixed the command check in the `ytm` function by changing `if len(message.command) == 1 and message.command[0] != "rpy":` to `if len(message.command) == 1 and message.command[0] != "ytm":`.

This change enhances the reliability of the paste functionality and corrects the command check logic in the `ytm` function.
