### PR TITLE
Check for sticker set name before accessing it

### DIFF
--- a/plugins/spowner.py
+++ b/plugins/spowner.py
@@ -27,7 +27,7 @@ async def search_user(client: Client, user_id: int):
 async def sticker_pack_owner(client: Client, message: Message):
     input_sticker_set = None
 
-    if message.reply_to_message.sticker:
+    if message.reply_to_message.sticker and message.reply_to_message.sticker.set_name:
         input_sticker_set = raw.types.InputStickerSetShortName(
             short_name=message.reply_to_message.sticker.set_name
         )

--- a/plugins/spowner.py
+++ b/plugins/spowner.py
@@ -27,7 +27,10 @@ async def search_user(client: Client, user_id: int):
 async def sticker_pack_owner(client: Client, message: Message):
     input_sticker_set = None
 
-    if message.reply_to_message.sticker and message.reply_to_message.sticker.set_name:
+    if message.reply_to_message.sticker:
+        if not message.reply_to_message.sticker.set_name:
+            return await message.edit("<b>Sticker should have a set name</b>")
+
         input_sticker_set = raw.types.InputStickerSetShortName(
             short_name=message.reply_to_message.sticker.set_name
         )


### PR DESCRIPTION
fixes error happin when used on non-set stickers:
```bash
2026-01-10 16:42:34 ERROR    pyrogram.dispatcher 'NoneType' object has no attribute 'encode'
Traceback (most recent call last):
  File "C:\Users\X\AppData\Local\Programs\Python\Python314\Lib\site-packages\pyrogram\dispatcher.py", line 373, in handler_worker
    await handler.callback(self.client, *args)
  File "f:\X\PP\Kurimuzon-Userbot\utils\scripts.py", line 115, in wrapped
    return await func(client, message)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "f:\X\PP\Kurimuzon-Userbot\plugins\spowner.py", line 49, in sticker_pack_owner
    if not input_sticker_set:
           ^^^^^^^^^^^^^^^^^
  File "C:\Users\X\AppData\Local\Programs\Python\Python314\Lib\site-packages\pyrogram\raw\core\tl_object.py", line 81, in __len__
    return len(self.write())
               ~~~~~~~~~~^^
  File "C:\Users\X\AppData\Local\Programs\Python\Python314\Lib\site-packages\pyrogram\raw\types\input_sticker_set_short_name.py", line 72, in write
            ~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\Users\X\AppData\Local\Programs\Python\Python314\Lib\site-packages\pyrogram\raw\core\primitives\string.py", line 31, in __new__
    return super().__new__(cls, value.encode())
                                ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'encode'
```