### PR TITLE
Refactor vnote function to use send_video_note

### DIFF
--- a/plugins/video_note.py
+++ b/plugins/video_note.py
@@ -8,7 +8,7 @@ from pyrogram.types import Message, ReplyParameters
 from utils.db import db
 from utils.filters import command
 from utils.misc import modules_help
-from utils.scripts import shell_exec
+from utils.scripts import shell_exec, with_reply
 
 
 @Client.on_message(
@@ -96,5 +96,87 @@ async def vnote(client: Client, message: Message):
         await message.delete()
 
 
+@Client.on_message(
+    ~filters.scheduled & command(["sticker"]) & filters.me & ~filters.forwarded
+)
+@with_reply
+async def sticker_cmd(client: Client, message: Message):
+    if not shutil.which("ffmpeg"):
+        return await message.edit("<b>ffmpeg not installed!</b>")
+
+    msg = message.reply_to_message
+
+    if not msg.media:
+        return await message.edit("<b>Replied message should contain media!</b>")
+
+    if msg.media not in (
+        enums.MessageMediaType.VIDEO,
+        enums.MessageMediaType.PHOTO,
+        enums.MessageMediaType.ANIMATION,
+    ):
+        return await message.edit("<b>Only video, photo, and gif supported!</b>")
+
+    await message.edit_text("<code>Converting to sticker...</code>")
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        input_file_path = os.path.join(tempdir, "input")
+        await msg.download(file_name=input_file_path)
+
+        is_video = msg.media in (
+            enums.MessageMediaType.VIDEO,
+            enums.MessageMediaType.ANIMATION,
+        )
+
+        if is_video:
+            output_file_path = os.path.join(tempdir, "output.webm")
+            # video sticker
+            cmd = (
+                f'ffmpeg -y -i "{input_file_path}" -t 3 -an -c:v libvpx-vp9 -pix_fmt yuva420p '
+                '-vf "fps=30,scale=512:512:force_original_aspect_ratio=decrease,pad=512:512:(ow-iw)/2:(oh-ih)/2:color=black@0" '
+                f'-b:v 500k "{output_file_path}"'
+            )
+        else:
+            output_file_path = os.path.join(tempdir, "output.webp")
+            # static sticker
+            cmd = (
+                f'ffmpeg -y -i "{input_file_path}" -vf '
+                '"scale=512:512:force_original_aspect_ratio=decrease,pad=512:512:(ow-iw)/2:(oh-ih)/2:color=black@0" '
+                f'-vframes 1 "{output_file_path}"'
+            )
+
+        _, _, stderr = await shell_exec(
+            command=cmd,
+            executable=db.get("shell", "executable"),
+        )
+
+        if (
+            not os.path.exists(output_file_path)
+            or os.path.getsize(output_file_path) == 0
+        ):
+            err = stderr or "Unknown ffmpeg error"
+            return await message.edit(
+                f"<b>Failed to convert to sticker.</b>\n\n<b>Error:</b>\n<code>{err}</code>"
+            )
+
+        try:
+            await client.send_sticker(
+                chat_id=message.chat.id,
+                sticker=output_file_path,
+                reply_parameters=ReplyParameters(
+                    message_id=msg.id,
+                    chat_id=msg.chat.id
+                    if not msg.chat.type == enums.ChatType.PRIVATE
+                    else None,
+                ),
+            )
+            await message.delete()
+        except (errors.ReplyMessageIdInvalid, errors.ChannelInvalid):
+            await message.reply_sticker(sticker=output_file_path)
+            await message.delete()
+        except Exception as e:
+            await message.edit(f"<b>Error sending sticker:</b>\n<code>{e}</code>")
+
+
 module = modules_help.add_module("vnote", __file__)
 module.add_command("vnote", "Make video note from message or reply media", "[reply]")
+module.add_command("sticker", "Make sticker from message or reply media", "[reply]")

--- a/plugins/video_note.py
+++ b/plugins/video_note.py
@@ -18,7 +18,10 @@ async def vnote(client: Client, message: Message):
     if not shutil.which("ffmpeg"):
         return await message.edit("<b>ffmpeg not installed!</b>")
 
-    if message.media:
+    if message.media and message.media in (
+        enums.MessageMediaType.VIDEO,
+        enums.MessageMediaType.ANIMATION,
+    ):
         message.empty = bool(await message.delete())
 
     if (

--- a/plugins/video_note.py
+++ b/plugins/video_note.py
@@ -132,6 +132,7 @@ async def sticker_cmd(client: Client, message: Message):
             # video sticker
             cmd = (
                 f'ffmpeg -y -i "{input_file_path}" -t 3 -an -c:v libvpx-vp9 -pix_fmt yuva420p '
+                "-row-mt 1 -deadline realtime -cpu-used 8 "
                 '-vf "fps=30,scale=512:512:force_original_aspect_ratio=decrease,pad=512:512:(ow-iw)/2:(oh-ih)/2:color=black@0" '
                 f'-b:v 500k "{output_file_path}"'
             )


### PR DESCRIPTION
1. checking if voice messages are forbidden in the chat before trying to download the file, this will save memory and bandwidth
2. using send_video_note with ReplyParameters because the old one when u reply on a media in different chat, your video note ended up in the other chat
3. deleting <code>Converting video...</code> after sending video note
4. formatted with ruff
5. fixing an error when u send non-video/gif with .vnote in the caption